### PR TITLE
Typo fix I forgot to send.

### DIFF
--- a/Doc/Reference/General/EventJumps.rst
+++ b/Doc/Reference/General/EventJumps.rst
@@ -55,7 +55,7 @@ Variant of ``"JumpToEventThenScene"``, but stays in in combat. Used for events w
 
 ::
 
-  "CallCombatEventThenScene", "EventNameHere", "SceneNameHere"
+  "CallCombatEventAndScene", "EventNameHere", "SceneNameHere"
 
 
 **JumpToNPCEventThenScene**

--- a/Homepage.rst
+++ b/Homepage.rst
@@ -5,7 +5,7 @@
 **Introduction**
 =================
 
-**Welcome to the Monster Girl Dreams Modding Documentation for v23.5c**.
+**Welcome to the Monster Girl Dreams Modding Documentation for v23.5f**.
 Here you can find information, reference, and starter guides for all JSON modding related practices.
 It features general starter information, all existing functions, and code block examples for everything you can do within the games custom scripting system.
 It assumes you already have at least a fair bit of experience with the game,
@@ -14,12 +14,14 @@ understand its stats via hovering over them in your character profile, and a fam
 Potential game spoilers abound.
 
 .. note::
+
   The game is still in active alpha development. Mods you make aren't guaranteed to work with the latest version of the game.
   Your mods are entirely up to you to maintain, unless someone decides to patch your mod for you.
   Warning probably sounds scarier than it actually is.
 
 **Navigating The Docs**
 ------------------------
+
 You will find all of the documentation content in the List of Contents below, and in the navigation column to the left.
 There are buttons at the bottom of each page if you wish to go through the documentation linearly.
 Of particular relevance to people new to modding will be the Starter section. Click 'Text Editors', or press the 'Next' button at the bottom of this page to begin.

--- a/index.rst
+++ b/index.rst
@@ -5,7 +5,7 @@
 **Introduction**
 =================
 
-**Welcome to the Monster Girl Dreams Modding Documentation for v23.5c**.
+**Welcome to the Monster Girl Dreams Modding Documentation for v23.5f**.
 Here you can find information, reference, and starter guides for all JSON modding related practices.
 It features general starter information, all existing functions, and code block examples for everything you can do within the games custom scripting system.
 It assumes you already have at least a fair bit of experience with the game,
@@ -14,6 +14,7 @@ understand its stats via hovering over them in your character profile, and a fam
 Potential game spoilers abound.
 
 .. note::
+
   The game is still in active alpha development. Mods you make aren't guaranteed to work with the latest version of the game.
   Your mods are entirely up to you to maintain, unless someone decides to patch your mod for you.
   Warning probably sounds scarier than it actually is.

--- a/index.rst
+++ b/index.rst
@@ -21,6 +21,7 @@ Potential game spoilers abound.
 
 **Navigating The Docs**
 ------------------------
+
 You will find all of the documentation content in the List of Contents below, and in the navigation column to the left.
 There are buttons at the bottom of each page if you wish to go through the documentation linearly.
 Of particular relevance to people new to modding will be the Starter section. Click 'Text Editors', or press the 'Next' button at the bottom of this page to begin.


### PR DESCRIPTION
Fixes a critical typo in a function example. This was supposed to be sent forever ago.